### PR TITLE
お気に入りのUserNameがうまく表示されないエラー修正

### DIFF
--- a/src/components/Ulkit/FavoListCard.jsx
+++ b/src/components/Ulkit/FavoListCard.jsx
@@ -42,7 +42,18 @@ const ListCard = (props) => {
 
   const [favo, setFavo] = useState(props.favo);
 
-  const username = props.username;
+  const [userName, setUserName] = useState("");
+
+  useEffect(() => {
+    if (props.uid !== undefined) {
+      const usersRef = db.collection("users").doc(props.uid);
+      usersRef.get().then((doc) => {
+        const data = doc.data();
+        const userName = data.username;
+        setUserName(userName);
+      });
+    }
+  }, [props.uid]);
 
   useEffect(() => {
     const favoRef = db
@@ -75,7 +86,7 @@ const ListCard = (props) => {
         videoid: props.videoid,
         youtubeurl: props.youtubeurl,
         favo: newfavo,
-        username: username,
+        username: userName,
       })
     );
   };
@@ -104,7 +115,7 @@ const ListCard = (props) => {
         </Typography>
         <div className="spacer--extra-extra-small" />
         <div className="right-bottom-position">
-          ユーザー名{username}
+          ユーザー名{userName}
           <IconButton
             onClick={() => {
               addFavo();

--- a/src/reducks/users/operations.js
+++ b/src/reducks/users/operations.js
@@ -187,6 +187,7 @@ export const savefavo = (addedfavo) => {
       .collection("favo")
       .doc(addedfavo.id);
     addedfavo["favoId"] = favoRef.id;
+    addedfavo["uid"] = uid;
 
     await favoRef.set(addedfavo, { merge: true });
 


### PR DESCRIPTION
ユーザー名を変更した後にお気に入りのユーザー名が変更されていないエラーをfirebase上の現在のユーザー名を参照することで
リアルタイムでユーザー名が更新されるようにした。